### PR TITLE
feat: user can delete task, home, and themselves

### DIFF
--- a/graphql/internal/database/database.go
+++ b/graphql/internal/database/database.go
@@ -23,17 +23,20 @@ type DAL interface {
 	GetUserByID(ctx context.Context, id string) (models.User, error)
 	GetUsersByName(ctx context.Context, name string) ([]models.User, error)
 	UpdateUser(ctx context.Context, user models.User) (models.User, error)
+	DeleteUser(ctx context.Context, userID string) error
 
 	//Home
 	CreateHome(ctx context.Context, home models.Home, userID string) (models.Home, error)
 	GetHomeByID(ctx context.Context, homeID *string) (models.Home, error)
 	UpdateHome(ctx context.Context, home models.Home) (models.Home, error)
+	DeleteHome(ctx context.Context, ID string) error
 
 	//Tasks
 	CreateTask(ctx context.Context, task models.Task, userID string) (models.Task, error)
 	UpdateTask(ctx context.Context, task models.Task) (models.Task, error)
 	GetTasksByUserID(ctx context.Context, userID string) ([]models.Task, error)
 	GetTaskByID(ctx context.Context, id string) (models.Task, error)
+	DeleteTask(ctx context.Context, ID string) error
 }
 
 func New(ctx context.Context, connStr string) (DAL, error) {

--- a/graphql/internal/database/migrations/1535501919_tasks.up.sql
+++ b/graphql/internal/database/migrations/1535501919_tasks.up.sql
@@ -2,7 +2,7 @@ CREATE TABLE tasks (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   title VARCHAR(64) NOT NULL,
   description VARCHAR(256),
-  user_id UUID NOT NULL REFERENCES users(id),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   created_at TIMESTAMP DEFAULT NOW(),
   updated_at TIMESTAMP DEFAULT NOW()
 );

--- a/graphql/internal/database/store.go
+++ b/graphql/internal/database/store.go
@@ -190,6 +190,18 @@ func (s *SQLStore) UpdateUser(ctx context.Context, user models.User) (models.Use
 	return user, nil
 }
 
+func (s *SQLStore) DeleteUser(ctx context.Context, userID string) error {
+	_, err := s.db.ExecContext(ctx, sqlDeleteUser, userID)
+	if err != nil {
+		log.Errorf("Error deleting user, %s", err)
+		return err
+	}
+
+	return nil
+}
+
+// --------------------- HOME METHODS --------------------- //
+
 // CreateHome function that will be used in the handlers
 func (s *SQLStore) CreateHome(ctx context.Context, home models.Home, userID string) (models.Home, error) {
 	err := s.db.QueryRowContext(
@@ -263,6 +275,16 @@ func (s *SQLStore) UpdateHome(ctx context.Context, home models.Home) (models.Hom
 		return home, err
 	}
 	return home, nil
+}
+
+func (s *SQLStore) DeleteHome(ctx context.Context, ID string) error {
+	_, err := s.db.ExecContext(ctx, sqlDeleteHome, ID)
+	if err != nil {
+		log.Errorf("Error deleting user, %s", err)
+		return err
+	}
+
+	return nil
 }
 
 // --------------------- TASKS METHODS ---------------------- //
@@ -373,6 +395,16 @@ func (s *SQLStore) GetTaskByID(ctx context.Context, id string) (models.Task, err
 	return t, err
 }
 
+func (s *SQLStore) DeleteTask(ctx context.Context, ID string) error {
+	_, err := s.db.ExecContext(ctx, sqlDeleteTask, ID)
+	if err != nil {
+		log.Errorf("Error deleting user, %s", err)
+		return err
+	}
+
+	return nil
+}
+
 const (
 
 	// Session Statements
@@ -427,6 +459,11 @@ const (
 	RETURNING first_name, last_name, home_id, email, avatar_url, updated_at, id
 	`
 
+	sqlDeleteUser = `
+	DELETE FROM users
+	WHERE id = $1
+	`
+
 	// Home Statements
 
 	sqlCreateHome = `
@@ -452,7 +489,12 @@ const (
 	RETURNING name, description, avatar_url, updated_at, id
 	`
 
+	sqlDeleteHome = `
+	DELETE FROM homes
+	WHERE id = $1
+	`
 	// Task Statements
+
 	sqlCreateTask = `
 	INSERT into tasks
 	(user_id, title, description)
@@ -479,4 +521,9 @@ const (
 			updated_at = $4
 	WHERE id = $5
 	RETURNING user_id, title, description, updated_at, id`
+
+	sqlDeleteTask = `
+	DELETE FROM tasks
+	WHERE id = $1
+	`
 )

--- a/graphql/internal/pubapi/pubapisrv/server_test.go
+++ b/graphql/internal/pubapi/pubapisrv/server_test.go
@@ -67,6 +67,17 @@ func (s *MockStore) UpdateHome(ctx context.Context, home models.Home) (models.Ho
 	return models.Home{}, errors.New("not implemented")
 }
 
+func (s *MockStore) DeleteHome(ctx context.Context, ID string) error {
+	return errors.New("not implemented")
+}
+
+func (s *MockStore) DeleteUser(ctx context.Context, ID string) error {
+	return errors.New("not implemented")
+}
+
+func (s *MockStore) DeleteTask(ctx context.Context, ID string) error {
+	return errors.New("not implemented")
+}
 func TestNewServer(t *testing.T) {
 	ctx := context.Background()
 	addr := "0.0.0.0:3000"

--- a/graphql/internal/resolver/resolver.go
+++ b/graphql/internal/resolver/resolver.go
@@ -131,7 +131,7 @@ func (r *Resolver) Users(ctx context.Context, args *struct {
 }
 
 // UpdateUser updates all fields on the user and returns the userResolver with that user
-func (r *Resolver) UpdateUser(ctx context.Context, args *struct {
+func (r *Resolver) UpdateUser(ctx context.Context, args struct {
 	User struct {
 		ID        string
 		FirstName *string
@@ -177,6 +177,18 @@ func (r *Resolver) UpdateUser(ctx context.Context, args *struct {
 	return &userResolver{u}, nil
 }
 
+func (r *Resolver) DeleteUser(ctx context.Context, args struct {
+	ID string
+}) (*userResolver, error) {
+	err := r.store.DeleteUser(ctx, args.ID)
+	if err != nil {
+		log.Errorf("Error deleting user: %s", err)
+		return nil, err
+	}
+
+	return &userResolver{}, nil
+}
+
 func (r *userResolver) ID() graphql.ID {
 	return graphql.ID(r.user.ID)
 }
@@ -188,6 +200,7 @@ func (r *userResolver) FirstName() string {
 func (r *userResolver) LastName() string {
 	return r.user.LastName
 }
+
 func (r *userResolver) Email() string {
 	return r.user.Email
 }
@@ -297,6 +310,18 @@ func (r *Resolver) UpdateTask(ctx context.Context, args *struct {
 	return &taskResolver{t}, nil
 }
 
+func (r *Resolver) DeleteTask(ctx context.Context, args struct {
+	ID string
+}) (*taskResolver, error) {
+	err := r.store.DeleteTask(ctx, args.ID)
+	if err != nil {
+		log.Errorf("Error deleting task: %s", err)
+		return nil, err
+	}
+
+	return &taskResolver{}, nil
+}
+
 type taskResolver struct {
 	task models.Task
 }
@@ -401,6 +426,18 @@ func (r *Resolver) UpdateHome(ctx context.Context, args *struct {
 	}
 
 	return &homeResolver{h}, nil
+}
+
+func (r *Resolver) DeleteHome(ctx context.Context, args struct {
+	ID string
+}) (*homeResolver, error) {
+	err := r.store.DeleteHome(ctx, args.ID)
+	if err != nil {
+		log.Errorf("Error deleting Home: %s", err)
+		return nil, err
+	}
+
+	return &homeResolver{}, nil
 }
 
 type homeResolver struct {

--- a/graphql/internal/schema/schema.go
+++ b/graphql/internal/schema/schema.go
@@ -17,20 +17,29 @@ var Schema = `
 		createHome(
 			name: String!,
 			description: String!
-		): Home!
+			): Home!
+		updateHome(
+			home: HomeInput!
+			): Home
+		deleteHome(
+			id: String!
+			): Home
 		createTask(
 			title: String!,
 			description: String!,
 			): Task!
-		updateUser(
-			user: UserInput!
-			): User!
 		updateTask(
 			task: TaskInput!
 			): Task!
-		updateHome(
-			home: HomeInput!
-			): Home
+		deleteTask(
+			id: String!
+			): Task
+		updateUser(
+			user: UserInput!
+			): User!
+		deleteUser(
+			id: String!
+			): User
 	}
 
 	type Viewer {


### PR DESCRIPTION
Closes #42 #44 #43 

Adds methods and resolvers on the Graphql side for deleting users, tasks, and homes. 

#### Changelog

**New**

- DeleteUser
- DeleteTask
- DeleteHome 

**Changed**

- Removed pointer in UpdateUser


